### PR TITLE
Fix bug in schema.prisma

### DIFF
--- a/examples/prisma/prisma/schema.prisma
+++ b/examples/prisma/prisma/schema.prisma
@@ -15,6 +15,7 @@ model Account {
   type               String
   provider           String
   providerAccountId  String
+  steamId            String
   refresh_token      String?  @db.Text
   access_token       String?  @db.Text
   expires_at         Int?


### PR DESCRIPTION
If steamId is not place in prisma model this error occured : 

![image](https://github.com/Nekonyx/next-auth-steam/assets/43297207/52837166-7492-490f-97da-0a97fc39286b)

When you add it to the model, the problem gone ✅ 

Thanks for this repo bro ! 